### PR TITLE
Persisting stats right after pomodoro is finished

### DIFF
--- a/Pomodoro/src/PomodoroController.m
+++ b/Pomodoro/src/PomodoroController.m
@@ -462,6 +462,8 @@
 	}
 	[self updateMenu];
 
+    // Save stats here in case application is forcefully terminated
+    [stats saveState];
 }
 
 - (void) oncePerSecondBreak:(NSNotification*) notification {


### PR DESCRIPTION
Made sure that stats are persisted in case application is forcefully terminated
