### PR TITLE
Add project names to entries loaded from Things

### DIFF
--- a/Pomodoro/scripts/getToDoListFromThings.applescript
+++ b/Pomodoro/scripts/getToDoListFromThings.applescript
@@ -1,7 +1,15 @@
 tell application "System Events" to if exists process "Things" then
-    tell application "Things"
-        tell list "Today"
-            get name of every to do whose status is equal to (open)
-        end tell
+tell application "Things"
+set todoList to {}
+repeat with aToDo in (to dos of list "Today" whose status is equal to (open))
+    set aProject to project of aToDo
+    if aProject is not missing value then
+        set prefix to "[" & (name of aProject) & "] "
+        else
+        set prefix to ""
+    end if
+    set end of todoList to (prefix & name of aToDo)
+end repeat
+return todoList
 end tell
 end if


### PR DESCRIPTION
I would like to add project name in pomodoro descriptions, so that I can calculate how much time I spend on each project. The new pomodoro descriptions now look like `[AI Course] Finish homework 4` if they are included in some project.
