### PR TITLE
Show Pomodoro Name in Menu Bar

### DIFF
--- a/Pomodoro.xcodeproj/project.pbxproj
+++ b/Pomodoro.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		69AE95DA133B4705004DC14D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0420;
 				ORGANIZATIONNAME = iUgol;
 			};
 			buildConfigurationList = 69AE95DD133B4705004DC14D /* Build configuration list for PBXProject "Pomodoro" */;

--- a/Pomodoro/Pomodoro-Info.plist
+++ b/Pomodoro/Pomodoro-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBuildNumber</key>
-	<integer>42</integer>
+	<integer>51</integer>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>

--- a/Pomodoro/src/PomodoroController.m
+++ b/Pomodoro/src/PomodoroController.m
@@ -45,12 +45,27 @@
 
 #pragma mark ---- Helper methods ----
 
-- (void) showTimeOnStatusBar:(NSInteger) time {	
-	if ([self checkDefault:@"showTimeOnStatusEnabled"]) {
-		[statusItem setTitle:[NSString stringWithFormat:@" %.2d:%.2d",time/60, time%60]];
-	} else {
-		[statusItem setTitle:@""];
-	}
+- (void) showTimeOnStatusBar:(NSInteger) time {
+    enum PomoState state = pomodoro.state;
+    if(state == PomoTicking){
+        if ([self checkDefault:@"showNameOnStatusEnabled"] && [self checkDefault:@"showTimeOnStatusEnabled"]) {
+            [statusItem setTitle:[NSString stringWithFormat:@" %@ - %.2d:%.2d",_pomodoroName, time/60, time%60]];
+        }
+        else if ([self checkDefault:@"showNameOnStatusEnabled"]) {
+            [statusItem setTitle:[NSString stringWithFormat:@" %@",_pomodoroName]];
+        }
+        else if ([self checkDefault:@"showTimeOnStatusEnabled"]) {
+            [statusItem setTitle:[NSString stringWithFormat:@"%.2d:%.2d", time/60, time%60]];
+        } else {
+            [statusItem setTitle:@""];
+        }
+    } else {
+        if ([self checkDefault:@"showTimeOnStatusEnabled"]) {
+            [statusItem setTitle:[NSString stringWithFormat:@"%.2d:%.2d", time/60, time%60]];
+        } else {
+            [statusItem setTitle:@""];
+        }
+    }
 }
 
 - (void) longBreakCheckerFinished {
@@ -584,6 +599,7 @@
 	[self observeUserDefault:@"tickVolume"];
 	[self observeUserDefault:@"initialTime"];
 	
+    [self observeUserDefault:@"showNameOnStatusEnabled"];
 	[self observeUserDefault:@"showTimeOnStatusEnabled"];
 	
 	if ([self checkDefault:@"showSplashScreenAtStartup"]) {

--- a/Pomodoro/src/PomodoroDefaults.m
+++ b/Pomodoro/src/PomodoroDefaults.m
@@ -161,6 +161,7 @@
 	[defaultValues setObject:[NSNumber numberWithInt:80] forKey:@"voiceVolume"];
 	[defaultValues setObject:[NSNumber numberWithInt:20] forKey:@"tickVolume"];
 	
+    [defaultValues setObject:[NSNumber numberWithBool:YES] forKey:@"showNameOnStatusEnabled"];
 	[defaultValues setObject:[NSNumber numberWithBool:YES] forKey:@"showTimeOnStatusEnabled"];
 	
 	[defaultValues setObject:[NSNumber numberWithBool:NO] forKey:@"calendarEnabled"];
@@ -314,6 +315,7 @@
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"ringBreakVolume"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"voiceVolume"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"tickVolume"];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"showNameOnStatusEnabled"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"showTimeOnStatusEnabled"];
 	
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"calendarEnabled"];


### PR DESCRIPTION
Adds the name of the current Pomodoro to the menu bar. I've found this is really helpful for keeping on track, especially during those difficult "debug feature foo on Facebook" Pomodoros. Not sure if you are interested and happy to mod as desired but thought I'd send it you an initial pull to get the conversation started.

Likely could use an option in the application (at present it's wired to a unsurfaced option like show time)

Thanks,
Kav
