### PR TITLE
Fix selection of new voices on Lion

### DIFF
--- a/Pomodoro/src/SpeechController.m
+++ b/Pomodoro/src/SpeechController.m
@@ -43,6 +43,16 @@
 
 #pragma mark ---- KVO Utility ----
 
+- (void)setVoiceByName:(NSString *)theName {
+    for (NSString *voiceId in voices) {
+        NSString *voiceName = [[NSSpeechSynthesizer attributesForVoice:voiceId] objectForKey:NSVoiceName];
+        if ([voiceName compare:theName] == NSOrderedSame) {
+            [speech setVoice:voiceId];
+            break;
+        }
+    }  
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath
 					  ofObject:(id)object
                         change:(NSDictionary *)change
@@ -60,8 +70,7 @@
             
         }
     } else if ([keyPath hasSuffix:@"Voice"]) {
-        NSString* voice = [[NSString stringWithFormat:@"com.apple.speech.synthesis.voice.%@", _speechVoice] stringByReplacingOccurrencesOfString:@" "withString:@""];
-        [speech setVoice: voice];
+        [self setVoiceByName:_speechVoice];
         [speech startSpeakingString:@"Yes"];
     }
     	
@@ -168,10 +177,8 @@
     voices = [[NSSpeechSynthesizer availableVoices] retain];
     
     [speech setVolume:_voiceVolume/100.0];
-
-    NSString* voice = [[NSString stringWithFormat:@"com.apple.speech.synthesis.voice.%@", _speechVoice] stringByReplacingOccurrencesOfString:@" "withString:@""];
-    [speech setVoice: voice];
-    
+    [self setVoiceByName:_speechVoice];
+   
     [self registerForAllPomodoroEvents];
     [self observeUserDefault:@"voiceVolume"];
     [self observeUserDefault:@"defaultVoice"];


### PR DESCRIPTION
Previously the code for selecting voice based on its name (but not id!)
assumed a certain format of voice identifier, and constructed this
identifier based on the name.

However, new voices available in OS X Lion (including Siri's Samantha
voice) use slightly different formats, and hence selecting them in
preferences did not work.

The code is now somewhat future proof by searching all the identifiers, and
comparing names for these identifiers with the name selected in
preferences.

Fixes #224
