### PR TITLE
Fixed <libxml/xmlreader.h> not found compilation error on Xcode 5 with OS X Mavericks

### DIFF
--- a/Pomodoro.xcodeproj/project.pbxproj
+++ b/Pomodoro.xcodeproj/project.pbxproj
@@ -1370,7 +1370,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Pomodoro/Pomodoro-Prefix.pch";
-				HEADER_SEARCH_PATHS = "/usr/include/libxml2/**";
+				HEADER_SEARCH_PATHS = "$(SDKROOT)/usr/include/libxml2/**";
 				INFOPLIST_FILE = "Pomodoro/Pomodoro-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -1391,7 +1391,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Pomodoro/Pomodoro-Prefix.pch";
-				HEADER_SEARCH_PATHS = "/usr/include/libxml2/**";
+				HEADER_SEARCH_PATHS = "$(SDKROOT)/usr/include/libxml2/**";
 				INFOPLIST_FILE = "Pomodoro/Pomodoro-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;


### PR DESCRIPTION
Wasn't able to compile on OSX Mavericks due to XML library not found error. 
I'm not sure if this is a Mavericks specific problem, and isn't public release yet so this pull request might be for future reference.

I do not have previous OS so need to verify if it still builds.

http://stackoverflow.com/questions/6592193/how-to-solve-libxml-xmlreader-h-not-found-error-in-twitter-integration-in-ipho
